### PR TITLE
Don't report markup titles as merge conflicts

### DIFF
--- a/pre_commit_hooks/check_merge_conflict.py
+++ b/pre_commit_hooks/check_merge_conflict.py
@@ -6,7 +6,8 @@ import sys
 
 CONFLICT_PATTERNS = [
     '<<<<<<< ',
-    '=======',
+    '======= ',
+    '=======\n',
     '>>>>>>> '
 ]
 WARNING_MSG = 'Merge conflict string "{0}" found in {1}:{2}'

--- a/tests/check_merge_conflict_test.py
+++ b/tests/check_merge_conflict_test.py
@@ -47,7 +47,7 @@ def f1_is_a_conflict_file(in_tmpdir):
 
 
 @pytest.mark.parametrize(
-    'failing_contents', ('<<<<<<< HEAD', '=======', '>>>>>>> master'),
+    'failing_contents', ('<<<<<<< HEAD\n', '=======\n', '>>>>>>> master\n'),
 )
 @pytest.mark.usefixtures('f1_is_a_conflict_file')
 def test_merge_conflicts_failing(failing_contents):
@@ -56,7 +56,7 @@ def test_merge_conflicts_failing(failing_contents):
 
 
 @pytest.mark.parametrize(
-    'ok_contents', ('# <<<<<<< HEAD', '# =======', 'import my_module', ''),
+    'ok_contents', ('# <<<<<<< HEAD\n', '# =======\n', 'import my_module', ''),
 )
 @pytest.mark.usefixtures('f1_is_a_conflict_file')
 def test_merge_conflicts_ok(ok_contents):
@@ -67,5 +67,5 @@ def test_merge_conflicts_ok(ok_contents):
 @pytest.mark.usefixtures('in_tmpdir')
 def test_does_not_care_when_not_in_a_conflict():
     with io.open('README.md', 'w') as readme_file:
-        readme_file.write('pre-commit\n=================\n')
+        readme_file.write('problem\n=======\n')
     assert detect_merge_conflict(['README.md']) == 0


### PR DESCRIPTION
Several markup formats, such as Markdown or Re(Structured)Text can format titles as text with '=' characters as double underlining, like this:
```
My Page Title
=============

Lorem ipsum...
```

Rather that considering any line starting with seven '=' as a conflict marker, require a space (or line-ending newline) after the equals.

This could still create a false positive for a seven character title, like "Problem", but the markup formats generally allow extra '=' characters, so by formatting the text like this:
```
Problem
========

Not...
```
these pre-commit warnings can be avoided.