### PR TITLE
Refactor check-merge-conflicts tests

### DIFF
--- a/pre_commit_hooks/check_merge_conflict.py
+++ b/pre_commit_hooks/check_merge_conflict.py
@@ -13,7 +13,7 @@ CONFLICT_PATTERNS = [
 WARNING_MSG = 'Merge conflict string "{0}" found in {1}:{2}'
 
 
-def is_in_merge_conflict():
+def is_in_merge():
     return (
         os.path.exists(os.path.join('.git', 'MERGE_MSG')) and
         os.path.exists(os.path.join('.git', 'MERGE_HEAD'))
@@ -25,7 +25,7 @@ def detect_merge_conflict(argv=None):
     parser.add_argument('filenames', nargs='*')
     args = parser.parse_args(argv)
 
-    if not is_in_merge_conflict():
+    if not is_in_merge():
         return 0
 
     retcode = 0

--- a/tests/check_merge_conflict_test.py
+++ b/tests/check_merge_conflict_test.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 
 import io
+import os
 
 import pytest
 
@@ -43,16 +44,51 @@ def f1_is_a_conflict_file(in_tmpdir):
             'parent\n'
             '>>>>>>>'
         )
+        assert os.path.exists(os.path.join('.git', 'MERGE_MSG'))
         yield
+
+
+@pytest.yield_fixture
+def repository_is_pending_merge(in_tmpdir):
+    # Make a (non-conflicting) merge
+    cmd_output('git', 'init', 'repo1')
+    with cwd('repo1'):
+        io.open('f1', 'w').close()
+        cmd_output('git', 'add', 'f1')
+        cmd_output('git', 'commit', '-m' 'commit1')
+
+    cmd_output('git', 'clone', 'repo1', 'repo2')
+
+    # Commit in master
+    with cwd('repo1'):
+        write_file('f1', 'parent\n')
+        cmd_output('git', 'commit', '-am', 'master commit2')
+
+    # Commit in clone and pull without committing
+    with cwd('repo2'):
+        write_file('f2', 'child\n')
+        cmd_output('git', 'add', 'f2')
+        cmd_output('git', 'commit', '-m', 'clone commit2')
+        cmd_output('git', 'pull', '--no-commit')
+        # We should end up in a pending merge
+        assert io.open('f1').read().startswith('parent\n')
+        assert io.open('f2').read().startswith('child\n')
+        assert os.path.exists(os.path.join('.git', 'MERGE_HEAD'))
+        yield
+
+
+@pytest.mark.usefixtures('f1_is_a_conflict_file')
+def test_merge_conflicts_git():
+    assert detect_merge_conflict(['f1']) == 1
 
 
 @pytest.mark.parametrize(
     'failing_contents', ('<<<<<<< HEAD\n', '=======\n', '>>>>>>> master\n'),
 )
-@pytest.mark.usefixtures('f1_is_a_conflict_file')
+@pytest.mark.usefixtures('repository_is_pending_merge')
 def test_merge_conflicts_failing(failing_contents):
-    write_file('f1', failing_contents)
-    assert detect_merge_conflict(['f1']) == 1
+    write_file('f2', failing_contents)
+    assert detect_merge_conflict(['f2']) == 1
 
 
 @pytest.mark.parametrize(
@@ -65,7 +101,7 @@ def test_merge_conflicts_ok(ok_contents):
 
 
 @pytest.mark.usefixtures('in_tmpdir')
-def test_does_not_care_when_not_in_a_conflict():
+def test_does_not_care_when_not_in_a_merge():
     with io.open('README.md', 'w') as readme_file:
         readme_file.write('problem\n=======\n')
     assert detect_merge_conflict(['README.md']) == 0


### PR DESCRIPTION
Do a straight test of detecting a real merge conflict as generated by git.
Test artificial conflict detection in a repository pending merge but without a real conflict.
Test artificial non-conflict non-detection in a real merge conflict that is resolved.
Rename test_does_not_care... function to truly reflect what we want to care about.

In the actual merge detection, rename `is_in_merge_conflict` to `is_in_merge`.